### PR TITLE
Fixed Empty Search Result in "Followed Repositories" Not Displaying Search Bar

### DIFF
--- a/client/src/FollowedRepositories.jsx
+++ b/client/src/FollowedRepositories.jsx
@@ -198,6 +198,18 @@ const FollowedRespositories = () => {
                 </Grid>
               </>
             ) : (
+            <>
+              <Box>
+                <SearchAndFilter
+                  filters={filtersWithValues}
+                  setFilters={(data) => {
+                    setFilters(data);
+                  }}
+                  setSearch={(data) => {
+                    setSearch(data);
+                  }}
+                />
+              </Box> 
               <Box>
                 <Grid
                   container
@@ -215,6 +227,7 @@ const FollowedRespositories = () => {
                   </Typography>
                 </Grid>
               </Box>
+            </>
             )}
           </Box>
         </Box>


### PR DESCRIPTION
Fixed front-end issue where when searching through followed repositories and when the search input does not match any of the followed repositories, you will no longer have access to the search bar. User must refresh the page to search through followed repositories again.

After fixing the issue, the search bar will no longer disappear and user can easily delete their input to make all results appear again.

Before fix:
![Screen Shot 2022-10-20 at 10 25 39 PM](https://user-images.githubusercontent.com/66925824/197096797-36326edf-fecc-4b93-ba6b-63b3641bc6b5.png)

After fix:
![Screen Shot 2022-10-20 at 10 25 23 PM](https://user-images.githubusercontent.com/66925824/197096817-0351d0b4-4254-4e56-bacf-ee6ad8ce0714.png)

