### PR TITLE
Fixed Empty Followed Repositories List Edge Case

### DIFF
--- a/client/src/FollowedRepositories.jsx
+++ b/client/src/FollowedRepositories.jsx
@@ -156,6 +156,28 @@ const FollowedRespositories = () => {
         <Box width="100%">
           <Title text="Followed Repositories" />
           <Box paddingLeft="4px">
+            {isEmpty(followedRepositories) ? (
+              <>
+                <Box>
+                <Grid
+                container
+                direction="column"
+                alignItems="center"
+                justifyContent="center"
+                style={{ minHeight: "70vh" }}
+              >
+                  <Typography variant="h4">
+                    You are not following any repositories!
+                  </Typography>
+                  <Typography>
+                    Go to the "Search Github" tab to search for repositories to
+                    follow
+                  </Typography>
+                </Grid>
+              </Box>
+            </>
+            ):(
+            <>
             {!isEmpty(paginatedData) ? (
               <>
                 <Box>
@@ -199,34 +221,36 @@ const FollowedRespositories = () => {
               </>
             ) : (
             <>
-              <Box>
-                <SearchAndFilter
-                  filters={filtersWithValues}
-                  setFilters={(data) => {
-                    setFilters(data);
-                  }}
-                  setSearch={(data) => {
-                    setSearch(data);
-                  }}
-                />
-              </Box> 
-              <Box>
-                <Grid
-                  container
-                  direction="column"
-                  alignItems="center"
-                  justifyContent="center"
-                  style={{ minHeight: "70vh" }}
-                >
-                  <Typography variant="h4">
-                    You are not following any repositories!
-                  </Typography>
-                  <Typography>
-                    Go to the "Search Github" tab to search for repositories to
-                    follow
-                  </Typography>
-                </Grid>
-              </Box>
+               <Box>
+                  <SearchAndFilter
+                    filters={filtersWithValues}
+                    setFilters={(data) => {
+                      setFilters(data);
+                    }}
+                    setSearch={(data) => {
+                      setSearch(data);
+                    }}
+                  />
+                </Box> 
+                <Box>
+                  <Grid
+                    container
+                    direction="column"
+                    alignItems="center"
+                    justifyContent="center"
+                    style={{ minHeight: "70vh" }}
+                  >
+                    <Typography variant="h4">
+                      You are not following any repositories!
+                    </Typography>
+                    <Typography>
+                      Go to the "Search Github" tab to search for repositories to
+                      follow
+                    </Typography>
+                  </Grid>
+                </Box>
+              </>
+            )}
             </>
             )}
           </Box>

--- a/client/src/FollowedRepositories.jsx
+++ b/client/src/FollowedRepositories.jsx
@@ -167,12 +167,12 @@ const FollowedRespositories = () => {
                 style={{ minHeight: "70vh" }}
               >
                   <Typography variant="h4">
-                    You are not following any repositories!
-                  </Typography>
-                  <Typography>
-                    Go to the "Search Github" tab to search for repositories to
-                    follow
-                  </Typography>
+                      You are not following any repositories!
+                    </Typography>
+                    <Typography>
+                      Go to the "Search Github" tab to search for repositories to
+                      follow
+                    </Typography>
                 </Grid>
               </Box>
             </>
@@ -241,12 +241,11 @@ const FollowedRespositories = () => {
                     style={{ minHeight: "70vh" }}
                   >
                     <Typography variant="h4">
-                      You are not following any repositories!
-                    </Typography>
-                    <Typography>
-                      Go to the "Search Github" tab to search for repositories to
-                      follow
-                    </Typography>
+                    Search result not found!
+                  </Typography>
+                  <Typography>
+                    Go to the "Search Github" tab to follow desired repositories
+                  </Typography>
                   </Grid>
                 </Box>
               </>


### PR DESCRIPTION
# Problem
- The problem started occurring after my recent change, where the website would crash on the /followed endpoint if a logged in user is following no repositories.
## Solution & Test
- Fixed this by first checking if the followedRepositories variable is empty, if so it will redirect you to a page where searching does not happen. If it is not, the logic of the previous change applies (#193). 
- Passes manual testing by trying both cases